### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN set -ex ;\
  chmod +x /start.sh
 
 USER mersdk
+WORKDIR /home/mersdk
 
 RUN set -ex ;\
 # create mersdk user with your local gid and uid to have write privileges during build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN set -ex ;\
 # copy sb2 targets config from nemo to mersdk user \
  cp -r /home/nemo/.scratchbox2 /home/mersdk ;\
 # change ownership from default nemo user to new mersdk one \
- chown mersdk:mersdk home/deploy ;\
+ chown mersdk:mersdk /home/deploy ;\
  chown -R mersdk:mersdk /home/mersdk/.scratchbox2/ ;\
  find /srv/mer/targets/* -print0 | xargs -0 --max-args=1 --max-procs=16 chown -h mersdk:mersdk ;\
 # transform platform sdk to application sdk \


### PR DESCRIPTION
With the new SDK 2.0 docker image I'm getting following Docker image build error:
```
+ chown mersdk:mersdk home/deploy
chown: cannot access `home/deploy': No such file or directory
```
I fixed it with using '/home/deploy' instead.

Then I had another build error:
```
OCI runtime create failed: container_linux.go:345: starting container process caused "chdir to cwd (\"/home/nemo\") set in config.json failed: permission denied": unknown
```
Fixed with using /home/mersdk as working directory.
